### PR TITLE
Local Caddy Server

### DIFF
--- a/caddyfile
+++ b/caddyfile
@@ -1,0 +1,9 @@
+:8443 {
+    root * ./build
+    file_server
+    encode gzip
+
+    tls internal {
+        on_demand
+    }
+}

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "vite dev",
     "build": "vite build",
-    "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "dev": "vite dev",
+    "preview": "vite preview"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "dev": "vite dev",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "serve": "./serve.sh"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^3.0.0",

--- a/serve.sh
+++ b/serve.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eo pipefail
+function ee {
+    printf "\e[2m$ %s\e[0m\n" "$*"
+    eval "$@"
+}
+
+echo 'Starting local Caddy web server.'
+echo -e '\e[1;35mURL: https://localhost:8443\e[0m'
+echo -e '\e[1;93mPress [Ctrl] + C to exit...\e[0m'
+
+ee "docker run -v \"\$(git rev-parse --show-toplevel):/http\" -w '/http' -p '8443:8443' caddy caddy run --config caddyfile"


### PR DESCRIPTION
From engineering [issue 99](https://github.com/eosnetworkfoundation/engineering/issues/99), this pull request adds a script to the `package.json` such that `yarn serve` uses the [Caddy](https://caddyserver.com) docker container to launch a local web server hosting the contents of the `/build` directory in a file server format, emulating a bucket locally.